### PR TITLE
fix: return newest console logs instead of oldest

### DIFF
--- a/extension/modules/tab-state.js
+++ b/extension/modules/tab-state.js
@@ -109,7 +109,8 @@ export class TabState {
     if (limit === null) {
       return [...logs];
     }
-    return logs.slice(-limit);
+    // Since logs are prepended (newest first), get first N items, not last N
+    return logs.slice(0, limit);
   }
 
   getConsoleLogCount() {


### PR DESCRIPTION
## Summary

Fixes a bug in the `console_logs` MCP tool where it was returning the oldest logs instead of the newest logs.

## Problem

Console logs are prepended to the array (newest first) using `unshift()` in `addConsoleLog()`, but the retrieval method `getConsoleLogs()` was using `slice(-limit)` which returns the LAST items from the array (oldest logs).

This meant when agents requested console logs with `limit: 100`, they received the **oldest 100 logs** instead of the **newest 100 logs**, making recent console output invisible.

## Solution

Changed `slice(-limit)` to `slice(0, limit)` to correctly return the first N items from the array, which are the newest logs.

## Files Changed

- `extension/modules/tab-state.js:112` - Changed slice logic to get first N items instead of last N items

## Testing

Before fix:
- Console logs returned old/stale output
- Recent `console.log()` statements were not visible in MCP tool results

After fix:
- Console logs return most recent output first
- Agents can see the latest console activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)