### PR TITLE
Bridge spawn robustness + connectivity/Windows hardening

### DIFF
--- a/extension/modules/background-navigate.js
+++ b/extension/modules/background-navigate.js
@@ -52,12 +52,17 @@ export async function forward({tabId}) {
 }
 
 export async function close({tabId}) {
+  // Verify the tab exists first so an invalid id still reports CLOSE_FAILED.
   try {
-    await chrome.tabs.remove(tabId);
-    return { success: true, closed: true };
+    await chrome.tabs.get(tabId);
   } catch (error) {
     return { success: false, error: { code: 'CLOSE_FAILED', message: error.message } };
   }
+  // Defer the actual removal so the command response is delivered before the
+  // tab's connection is torn down. Removing it synchronously drops the ack and
+  // the client times out waiting for it.
+  setTimeout(() => { chrome.tabs.remove(tabId).catch(() => {}); }, 0);
+  return { success: true, closed: true };
 }
 
 export async function reload({tabId}) {

--- a/extension/modules/tab-state.js
+++ b/extension/modules/tab-state.js
@@ -48,7 +48,7 @@ export class TabState {
   constructor(tabId) {
     this.tabId = tabId;
     this.websocket = null;
-    this.connectionInfo = new ConnectionInfo('ws://localhost:61822');
+    this.connectionInfo = new ConnectionInfo('ws://127.0.0.1:61822');
     this.messages = [];
     this.consoleLogs = [];
     this.ports = new Set(); // Connected DevTools panels/popups

--- a/server/package.json
+++ b/server/package.json
@@ -31,6 +31,7 @@
     "build": "tsc && cp src/*.yaml dist/ && chmod +x dist/cli.js dist/index.js dist/bridge.js dist/setup.js",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
+    "test": "tsx --test src/*.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/server/src/assistant-manager.ts
+++ b/server/src/assistant-manager.ts
@@ -29,12 +29,12 @@ const ASSISTANTS: Record<string, AssistantConfig> = {
     key: 'claude-desktop',
     configPaths: {
       darwin: join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json'),
-      win32: join(process.env.APPDATA || '', 'Claude', 'claude_desktop_config.json'),
+      win32: process.env.APPDATA ? join(process.env.APPDATA, 'Claude', 'claude_desktop_config.json') : undefined,
       linux: join(homedir(), '.config', 'Claude', 'claude_desktop_config.json')
     },
     appPaths: {
       darwin: '/Applications/Claude.app',
-      win32: join(process.env.PROGRAMFILES || '', 'Claude', 'Claude.exe'),
+      win32: process.env.PROGRAMFILES ? join(process.env.PROGRAMFILES, 'Claude', 'Claude.exe') : undefined,
       linux: '/usr/bin/claude-desktop'
     },
     configKey: 'mcpServers'
@@ -52,12 +52,12 @@ const ASSISTANTS: Record<string, AssistantConfig> = {
     key: 'vscode',
     configPaths: {
       darwin: join(homedir(), 'Library', 'Application Support', 'Code', 'User', 'settings.json'),
-      win32: join(process.env.APPDATA || '', 'Code', 'User', 'settings.json'),
+      win32: process.env.APPDATA ? join(process.env.APPDATA, 'Code', 'User', 'settings.json') : undefined,
       linux: join(homedir(), '.config', 'Code', 'User', 'settings.json')
     },
     appPaths: {
       darwin: '/Applications/Visual Studio Code.app',
-      win32: join(process.env.PROGRAMFILES || '', 'Microsoft VS Code', 'Code.exe'),
+      win32: process.env.PROGRAMFILES ? join(process.env.PROGRAMFILES, 'Microsoft VS Code', 'Code.exe') : undefined,
       linux: '/usr/bin/code'
     },
     configKey: 'mcp.servers'
@@ -71,7 +71,7 @@ const ASSISTANTS: Record<string, AssistantConfig> = {
     },
     appPaths: {
       darwin: '/Applications/Cursor.app',
-      win32: join(process.env.LOCALAPPDATA || '', 'Programs', 'cursor', 'Cursor.exe'),
+      win32: process.env.LOCALAPPDATA ? join(process.env.LOCALAPPDATA, 'Programs', 'cursor', 'Cursor.exe') : undefined,
       linux: '/usr/bin/cursor'
     },
     configKey: 'mcpServers'

--- a/server/src/bridge-lib.test.ts
+++ b/server/src/bridge-lib.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'net';
+import { probe, waitForPort } from './bridge-lib.js';
+
+test('waitForPort fails fast within its timeout budget when the server never comes up', async () => {
+  // Regression guard for issue #7: when the spawned server never binds the
+  // port, the bridge must give up within its window instead of hanging ~60s
+  // on a WebSocket connect that never succeeds.
+  const start = Date.now();
+  const ok = await waitForPort('127.0.0.1', 0, {
+    probeFn: async () => false,
+    timeoutMs: 1000,
+    stepMs: 100,
+  });
+  const elapsed = Date.now() - start;
+
+  assert.equal(ok, false);
+  assert.ok(elapsed >= 1000, `gave up before the timeout budget (${elapsed}ms)`);
+  assert.ok(elapsed < 3000, `took far longer than the timeout budget (${elapsed}ms)`);
+});
+
+test('waitForPort resolves immediately once a probe succeeds', async () => {
+  const start = Date.now();
+  const ok = await waitForPort('127.0.0.1', 0, {
+    probeFn: async () => true,
+    timeoutMs: 5000,
+    stepMs: 250,
+  });
+
+  assert.equal(ok, true);
+  assert.ok(Date.now() - start < 250, 'should not wait when the first probe succeeds');
+});
+
+test('probe returns true for a listening port and false once it is closed', async () => {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const { port } = server.address() as net.AddressInfo;
+
+  assert.equal(await probe('127.0.0.1', port), true, 'listening port should be reachable');
+
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+
+  assert.equal(await probe('127.0.0.1', port), false, 'closed port should be unreachable');
+});

--- a/server/src/bridge-lib.ts
+++ b/server/src/bridge-lib.ts
@@ -1,0 +1,47 @@
+import net from 'net';
+
+/**
+ * Resolve true if a TCP connection to host:port succeeds within timeoutMs.
+ * Used to detect whether the Kapture server is already listening before the
+ * bridge spawns its own, and to poll for the server coming up.
+ */
+export function probe(host: string, port: number, timeoutMs = 1000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const finish = (result: boolean) => {
+      socket.destroy();
+      resolve(result);
+    };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => finish(true));
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+    socket.connect(port, host);
+  });
+}
+
+export interface WaitForPortOptions {
+  timeoutMs?: number;
+  stepMs?: number;
+  probeFn?: (host: string, port: number) => Promise<boolean>;
+}
+
+/**
+ * Poll host:port until it accepts a connection or the timeout elapses.
+ * Returns true as soon as a probe succeeds, false if the budget runs out.
+ */
+export async function waitForPort(
+  host: string,
+  port: number,
+  options: WaitForPortOptions = {}
+): Promise<boolean> {
+  const { timeoutMs = 15000, stepMs = 250, probeFn = probe } = options;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await probeFn(host, port)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+  return false;
+}

--- a/server/src/bridge.ts
+++ b/server/src/bridge.ts
@@ -4,6 +4,9 @@ import { spawn } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { createRequire } from 'module';
+import { openSync } from 'fs';
+import { tmpdir } from 'os';
+import { probe, waitForPort } from './bridge-lib.js';
 
 process.title = 'Kapture MCP Bridge';
 
@@ -13,22 +16,47 @@ const __dirname = dirname(__filename);
 
 const MCPWebSocketBridge = require('mcp2websocket');
 
+const HOST = '127.0.0.1';
+const PORT = 61822;
 const serverPath = join(__dirname, 'index.js');
-const serverProcess = spawn(process.execPath, [serverPath], {
-  detached: true,
-  stdio: 'ignore'
-});
+const logPath = join(tmpdir(), 'kapture-server.log');
 
-serverProcess.unref();
+async function main() {
+  // Probe before spawning: if a server (or an external supervisor) is already
+  // listening, skip the spawn entirely so the bridge is idempotent and tolerant
+  // of environments where the detached child can't take (e.g. Claude Desktop's
+  // built-in Node runtime). See issue #7.
+  if (!(await probe(HOST, PORT))) {
+    // Capture the child's stderr to a log file instead of discarding it, so a
+    // failed spawn is diagnosable rather than silent.
+    const log = openSync(logPath, 'a');
+    const serverProcess = spawn(process.execPath, [serverPath], {
+      detached: true,
+      stdio: ['ignore', log, log]
+    });
+    serverProcess.on('error', (error) => {
+      console.error('Failed to spawn Kapture server:', error);
+    });
+    serverProcess.unref();
+  }
 
-setTimeout(() => {
-  try {
-    const bridge = new MCPWebSocketBridge('ws://localhost:61822/mcp', {});
-    bridge.start();
-    // Keep the process alive
-    process.stdin.resume();
-  } catch (error) {
-    console.error('Failed to start bridge:', error);
+  // Wait for the server to actually bind the port instead of a fixed delay,
+  // and fail loudly if it never comes up rather than hanging on the WebSocket
+  // connect (which surfaces to the client as a silent ~60s timeout).
+  if (!(await waitForPort(HOST, PORT))) {
+    console.error(
+      `Kapture server never bound ${HOST}:${PORT}. See ${logPath} for details.`
+    );
     process.exit(1);
   }
-}, 1000);
+
+  const bridge = new MCPWebSocketBridge(`ws://${HOST}:${PORT}/mcp`, {});
+  bridge.start();
+  // Keep the process alive
+  process.stdin.resume();
+}
+
+main().catch((error) => {
+  console.error('Failed to start bridge:', error);
+  process.exit(1);
+});

--- a/server/src/browser-command-handler.ts
+++ b/server/src/browser-command-handler.ts
@@ -117,7 +117,7 @@ export class BrowserCommandHandler {
         command = `start ${exeName} "${targetUrl}"`;
       } else {
         // Use system default browser
-        command = `start "${targetUrl}"`;
+        command = `start "" "${targetUrl}"`;
       }
     } else {
       // Linux

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -262,20 +262,20 @@ wss.on('connection', (ws, request) => {
 async function startServer() {
   await checkIfPortInUse(PORT);
 
-  httpServer.listen(PORT, () => {
+  httpServer.listen(PORT, '127.0.0.1', () => {
     console.log('='.repeat(70));
     console.log('Kapture MCP Server Started');
     console.log();
     console.log('HTTP Endpoints:');
-    console.log(`  Discovery: http://localhost:${PORT}/`);
-    console.log(`  Resources: http://localhost:${PORT}/tabs`);
-    console.log(`  Tab info: http://localhost:${PORT}/tab/{tabId}`);
-    console.log(`  Console: http://localhost:${PORT}/tab/{tabId}/console`);
-    console.log(`  Screenshot: http://localhost:${PORT}/tab/{tabId}/screenshot`);
-    console.log(`  View image: http://localhost:${PORT}/tab/{tabId}/screenshot/view`);
-    console.log(`  Elements: http://localhost:${PORT}/tab/{tabId}/elements`);
-    console.log(`  Point query: http://localhost:${PORT}/tab/{tabId}/elementsFromPoint`);
-    console.log(`  DOM: http://localhost:${PORT}/tab/{tabId}/dom`);
+    console.log(`  Discovery: http://127.0.0.1:${PORT}/`);
+    console.log(`  Resources: http://127.0.0.1:${PORT}/tabs`);
+    console.log(`  Tab info: http://127.0.0.1:${PORT}/tab/{tabId}`);
+    console.log(`  Console: http://127.0.0.1:${PORT}/tab/{tabId}/console`);
+    console.log(`  Screenshot: http://127.0.0.1:${PORT}/tab/{tabId}/screenshot`);
+    console.log(`  View image: http://127.0.0.1:${PORT}/tab/{tabId}/screenshot/view`);
+    console.log(`  Elements: http://127.0.0.1:${PORT}/tab/{tabId}/elements`);
+    console.log(`  Point query: http://127.0.0.1:${PORT}/tab/{tabId}/elementsFromPoint`);
+    console.log(`  DOM: http://127.0.0.1:${PORT}/tab/{tabId}/dom`);
     console.log('='.repeat(70));
   });
 }

--- a/server/src/port-check.ts
+++ b/server/src/port-check.ts
@@ -31,7 +31,9 @@ async function getPortInfo(port: number): Promise<{ inUse: boolean; pid?: string
         command: parts[0]
       };
     } else if (platform === 'win32') {
-      const parts = stdout.trim().split(/\s+/);
+      const lines = stdout.trim().split('\n');
+      const listenLine = lines.find(l => l.includes('LISTENING')) || lines[0];
+      const parts = listenLine.trim().split(/\s+/);
       const pid = parts[parts.length - 1];
       return {
         inUse: true,

--- a/server/src/setup.ts
+++ b/server/src/setup.ts
@@ -11,7 +11,7 @@ process.title = 'Kapture Setup';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const localhost_welcome = 'http://localhost:61822/welcome';
+const localhost_welcome = 'http://127.0.0.1:61822/welcome';
 
 async function setup() {
   console.log('Setup Server...');
@@ -40,7 +40,7 @@ async function setup() {
 
   try {
 
-    const transport = new WebSocketClientTransport(new URL('ws://localhost:61822/mcp'));
+    const transport = new WebSocketClientTransport(new URL('ws://127.0.0.1:61822/mcp'));
     await client.connect(transport);
 
     // Keep looking for the welcome tab

--- a/server/src/tool-handler.ts
+++ b/server/src/tool-handler.ts
@@ -76,7 +76,7 @@ export class ToolHandler {
         if (screenshotArgs?.quality) params.append('quality', String(screenshotArgs.quality));
 
         const queryString = params.toString();
-        const screenshotUrl = `http://localhost:61822/tab/${screenshotArgs?.tabId}/screenshot/view${queryString ? '?' + queryString : ''}`;
+        const screenshotUrl = `http://127.0.0.1:61822/tab/${screenshotArgs?.tabId}/screenshot/view${queryString ? '?' + queryString : ''}`;
 
         const enhancedResult = {
           preview: screenshotUrl,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -16,5 +16,5 @@
     "sourceMap": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Makes the bridge reliably bring up the server under host runtimes where a
detached child doesn't survive (notably Claude Desktop's bundled Node), pins
all local traffic to IPv4 `127.0.0.1`, and fixes the Windows `new_tab`
command-prompt bug and a `close`-tab response race.

## Background

`#2`, `#7`, `#9`, and `#13` are the same root cause: when `bridge.js` runs
under Claude Desktop's bundled Node, the detached server child never binds the
port, the WebSocket connect hangs, and the client cancels after 60s with
`-32001`. `stdio: 'ignore'` was swallowing the spawn error so there was no
diagnostic. Reproduced on macOS and Windows.

## Changes

**Bridge (`bridge.ts`, `bridge-lib.ts`)**
- Probe `127.0.0.1:61822` before spawning, so the bridge is idempotent and
  connects to an already-running server instead of depending on whichever
  Node launched it.
- Send the spawned server's output to a temp log instead of discarding it.
- Poll for the port to bind (bounded) instead of a fixed 1s delay, and exit
  with a clear error if it never comes up instead of hanging on the connect.
- Pulled probe/`waitForPort` into `bridge-lib.ts` with unit tests.

**IPv4 pinning**
- Bind the server to `127.0.0.1` (loopback only) and point every client URL
  (bridge, setup, screenshot preview, extension WebSocket) at `127.0.0.1`, so
  there's no `localhost`/`::1` ambiguity.

**Windows**
- `new_tab` default-browser path uses `start "" "<url>"` — `start` was reading
  the URL as a window title and opening a cmd window instead of a tab (#10).
- Parse the `LISTENING` line from `netstat` correctly in `port-check`.

**Setup**
- Assistant config/app paths resolve to `undefined` when an env var is missing
  instead of a bogus relative path.

**Extension (`background-navigate.js`)**
- `close` now checks the tab exists, then defers `chrome.tabs.remove` so the
  `{closed:true}` ack goes out before the connection is torn down. It was
  removing the tab first, which dropped the response and timed out the client.

## Testing

- `bridge-lib` unit tests pass.
- Verified under Claude Desktop's bundled Node: cold start binds
  `127.0.0.1:61822` and completes the MCP handshake in ~6s, no timeout.
- Exercised `new_tab` / `navigate` / `dom` / `elements` / `screenshot` /
  `console_logs` / `close` via MCP.

Fixes #7
Fixes #10

Related: #2, #9, #13 (same root cause).
