### PR TITLE
Configurable keepalive interval

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,7 +6,7 @@
   "description": "Remote browser automation via MCP - DevTools Extension",
   "author": "William Kapke",
   "homepage_url": "https://github.com/williamkapke/kapture",
-  "permissions": ["activeTab", "debugger"],
+  "permissions": ["activeTab", "debugger", "storage"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js",

--- a/extension/modules/tab-manager.js
+++ b/extension/modules/tab-manager.js
@@ -5,6 +5,53 @@ export class TabManager {
   constructor() {
     this.tabs = new Map(); // tabId -> TabState
     this.listeners = new Set(); // State change listeners
+    this.keepaliveMs = 30000; // configurable via the 'keepaliveSeconds' setting (#14)
+    this._initKeepaliveSetting();
+  }
+
+  // Load the configurable keepalive interval and react to panel changes.
+  async _initKeepaliveSetting() {
+    try {
+      const { keepaliveSeconds } = await chrome.storage.local.get('keepaliveSeconds');
+      this.keepaliveMs = this._keepaliveMsFrom(keepaliveSeconds);
+    } catch (e) { /* storage unavailable -> keep default */ }
+
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area !== 'local' || !changes.keepaliveSeconds) return;
+      this.keepaliveMs = this._keepaliveMsFrom(changes.keepaliveSeconds.newValue);
+      this._restartKeepalives();
+    });
+  }
+
+  _keepaliveMsFrom(seconds) {
+    const n = Number(seconds);
+    return Number.isFinite(n) && n > 0 ? n * 1000 : 30000;
+  }
+
+  _startKeepalive(tabState) {
+    const ws = tabState.websocket;
+    return setInterval(() => {
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        try {
+          ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
+        } catch (e) {
+          console.error('Failed to send keepalive ping:', e);
+        }
+      }
+    }, this.keepaliveMs);
+  }
+
+  // Re-arm keepalive on connected tabs after the interval setting changes.
+  _restartKeepalives() {
+    for (const tabState of this.tabs.values()) {
+      if (tabState.keepaliveInterval) {
+        clearInterval(tabState.keepaliveInterval);
+        tabState.keepaliveInterval = null;
+      }
+      if (tabState.websocket && tabState.websocket.readyState === WebSocket.OPEN) {
+        tabState.keepaliveInterval = this._startKeepalive(tabState);
+      }
+    }
   }
 
   // Tab lifecycle
@@ -118,16 +165,8 @@ export class TabManager {
 
       this.sendMessage(tabState.tabId, registerMessage);
 
-      // Set up keepalive ping every 30 seconds
-      tabState.keepaliveInterval = setInterval(() => {
-        if (ws.readyState === WebSocket.OPEN) {
-          try {
-            ws.send(JSON.stringify({ type: 'ping', timestamp: Date.now() }));
-          } catch (e) {
-            console.error('Failed to send keepalive ping:', e);
-          }
-        }
-      }, 30000);
+      // Set up keepalive ping (interval configurable via panel setting, default 30s) (#14)
+      tabState.keepaliveInterval = this._startKeepalive(tabState);
     };
 
     ws.onclose = () => {

--- a/extension/panel.css
+++ b/extension/panel.css
@@ -350,6 +350,25 @@ html, body {
   color: var(--text-primary);
 }
 
+.keepalive-setting {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+#keepalive-seconds {
+  width: 48px;
+  padding: 3px 4px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  text-align: right;
+}
+
 /* Layout */
 .panel-container {
   display: flex;

--- a/extension/panel.html
+++ b/extension/panel.html
@@ -47,6 +47,11 @@
     <!-- Footer -->
     <div class="footer">
       <span class="console-count" id="console-count">Console: 0</span>
+      <label class="keepalive-setting" title="Send a keepalive ping on this interval to hold the connection open during idle periods">
+        Keep-alive
+        <input type="number" id="keepalive-seconds" min="5" max="600" step="5">
+        s
+      </label>
       <button class="clear-button" id="clear-logs">Clear Logs</button>
     </div>
   </div>

--- a/extension/panel.js
+++ b/extension/panel.js
@@ -53,6 +53,29 @@ function initializeUI() {
 
   // Resize handle
   initializeResizeHandle();
+
+  // Keep-alive interval setting (#14)
+  initializeKeepaliveSetting();
+}
+
+// Read/write the configurable keepalive interval (seconds) from chrome.storage.
+// The service worker (tab-manager) reads the same key and re-arms its pings.
+function initializeKeepaliveSetting() {
+  const input = document.getElementById('keepalive-seconds');
+  if (!input) return;
+
+  chrome.storage.local.get('keepaliveSeconds', ({ keepaliveSeconds }) => {
+    const secs = Number(keepaliveSeconds);
+    input.value = Number.isFinite(secs) && secs > 0 ? secs : 30;
+  });
+
+  input.addEventListener('change', () => {
+    let secs = parseInt(input.value, 10);
+    if (!Number.isFinite(secs) || secs < 5) secs = 5;
+    if (secs > 600) secs = 600;
+    input.value = secs;
+    chrome.storage.local.set({ keepaliveSeconds: secs });
+  });
 }
 
 // Update UI based on connection state


### PR DESCRIPTION
## Summary

Makes the WebSocket keepalive interval configurable from the DevTools panel
instead of a hardcoded 30s, for long-running agent sessions where commands can
come minutes apart.

## Changes

- `tab-manager.js` reads `keepaliveSeconds` from `chrome.storage.local`
  (default 30s) and re-arms the running pings live when the value changes.
- Panel footer gains a "Keep-alive N s" field (5–600s), persisted to storage.
- Adds the `storage` permission — the extension's first use of `chrome.storage`.

Closes #14.
