### PR TITLE
fix: host the MCP server in-process when the bridge can't keep a detached child (#13)

### DIFF
--- a/server/src/bridge-lib.test.ts
+++ b/server/src/bridge-lib.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import net from 'net';
-import { probe, waitForPort } from './bridge-lib.js';
+import { probe, waitForPort, ensureServer } from './bridge-lib.js';
 
 test('waitForPort fails fast within its timeout budget when the server never comes up', async () => {
   // Regression guard for issue #7: when the spawned server never binds the
@@ -42,4 +42,147 @@ test('probe returns true for a listening port and false once it is closed', asyn
   await new Promise<void>((resolve) => server.close(() => resolve()));
 
   assert.equal(await probe('127.0.0.1', port), false, 'closed port should be unreachable');
+});
+
+test('ensureServer reuses an already-running server without spawning or hosting in-process', async () => {
+  let spawned = false;
+  let inProcess = false;
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => true,
+    waitFn: async () => {
+      throw new Error('waitForPort should not run when a server is already up');
+    },
+    spawnDetached: () => {
+      spawned = true;
+    },
+    startInProcess: async () => {
+      inProcess = true;
+    },
+  });
+
+  assert.equal(outcome, 'already-running');
+  assert.equal(spawned, false, 'must not spawn when a server is already listening');
+  assert.equal(inProcess, false, 'must not host in-process when a server is already listening');
+});
+
+test('ensureServer uses the detached spawn when it successfully binds the port', async () => {
+  let inProcess = false;
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => false,
+    waitFn: async () => true, // the spawned child bound the port
+    spawnDetached: () => {},
+    startInProcess: async () => {
+      inProcess = true;
+    },
+  });
+
+  assert.equal(outcome, 'spawned');
+  assert.equal(inProcess, false, 'must not host in-process when the detached child works');
+});
+
+test('ensureServer falls back to in-process hosting when the detached child never binds (issue #13)', async () => {
+  // Reproduces "Unable to connect to extension server": under a host whose
+  // bundled Node cannot keep a detached child alive (e.g. Claude Desktop's
+  // runtime), the spawned server never binds the port. The bridge must then
+  // host the server inside its own process instead of giving up with exit(1).
+  let inProcessStarted = false;
+  let waitCalls = 0;
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => false,
+    waitFn: async () => {
+      waitCalls += 1;
+      // First wait (after the detached spawn) fails; second wait (after the
+      // in-process start) succeeds.
+      return waitCalls >= 2;
+    },
+    spawnDetached: () => {},
+    startInProcess: async () => {
+      inProcessStarted = true;
+    },
+  });
+
+  assert.equal(inProcessStarted, true, 'must host the server in-process when the detached child never binds');
+  assert.equal(outcome, 'in-process');
+});
+
+test('ensureServer still falls back to in-process hosting when the detached spawn itself throws', async () => {
+  // spawnDetached is best-effort: a throw (e.g. failing to open the spawn log)
+  // must not abort the guaranteed in-process fallback.
+  let inProcessStarted = false;
+  let waitCalls = 0;
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => false,
+    waitFn: async () => {
+      waitCalls += 1;
+      return waitCalls >= 2;
+    },
+    spawnDetached: () => {
+      throw new Error('EACCES: cannot open spawn log');
+    },
+    startInProcess: async () => {
+      inProcessStarted = true;
+    },
+  });
+
+  assert.equal(inProcessStarted, true, 'a throwing detached spawn must not skip the in-process fallback');
+  assert.equal(outcome, 'in-process');
+});
+
+test('ensureServer reports failure when neither the detached child nor in-process hosting binds', async () => {
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => false,
+    waitFn: async () => false, // never binds, even after the in-process start
+    spawnDetached: () => {},
+    startInProcess: async () => {},
+  });
+
+  assert.equal(outcome, 'failed');
+});
+
+test('ensureServer reports failure when in-process hosting throws', async () => {
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => false,
+    waitFn: async () => false,
+    spawnDetached: () => {},
+    startInProcess: async () => {
+      throw new Error('in-process start failed');
+    },
+  });
+
+  assert.equal(outcome, 'failed');
+});
+
+test('ensureServer treats an in-process EADDRINUSE as success when a racing child won the port', async () => {
+  // A slow detached child can bind the port just as the in-process listen
+  // fires, throwing EADDRINUSE. The server is still up, so this must not fail.
+  let probeCalls = 0;
+  const outcome = await ensureServer({
+    host: '127.0.0.1',
+    port: 61822,
+    probeFn: async () => {
+      probeCalls += 1;
+      // First probe (step 1): nothing up yet. Probe after the throw: the racing
+      // child has now bound the port.
+      return probeCalls > 1;
+    },
+    waitFn: async () => false, // the detached child hadn't bound within the window
+    spawnDetached: () => {},
+    startInProcess: async () => {
+      throw new Error('listen EADDRINUSE 127.0.0.1:61822');
+    },
+  });
+
+  assert.equal(outcome, 'already-running');
 });

--- a/server/src/bridge-lib.ts
+++ b/server/src/bridge-lib.ts
@@ -45,3 +45,90 @@ export async function waitForPort(
   }
   return false;
 }
+
+export type EnsureServerOutcome = 'already-running' | 'spawned' | 'in-process' | 'failed';
+
+export interface EnsureServerOptions {
+  host: string;
+  port: number;
+  /** Best-effort detached spawn of a standalone server process (must not throw). */
+  spawnDetached: () => void;
+  /** Host the server inside the current process; resolves once it is listening. */
+  startInProcess: () => Promise<void>;
+  probeFn?: (host: string, port: number) => Promise<boolean>;
+  waitFn?: (host: string, port: number, options?: WaitForPortOptions) => Promise<boolean>;
+  /** How long to wait for the detached child to bind before falling back. */
+  spawnWaitMs?: number;
+  /** How long to wait for the in-process server to bind. */
+  inProcessWaitMs?: number;
+  /** Diagnostic sink; defaults to a no-op. Never write to stdout (MCP channel). */
+  log?: (message: string) => void;
+}
+
+/**
+ * Make sure a Kapture server is listening on host:port, returning how it got
+ * there. The strategy, in order:
+ *
+ *   1. If a server is already listening, reuse it (multiple MCP clients share
+ *      one server so they see the same browser tabs).
+ *   2. Otherwise spawn a standalone server as a detached child and wait for it
+ *      to bind. This keeps the shared-server model when the host can keep a
+ *      detached child alive (e.g. a real `node` from a terminal or Claude Code).
+ *   3. If that child never binds the port, host the server *inside this
+ *      process* instead. This is the fix for issue #13 ("Unable to connect to
+ *      extension server"): under hosts whose bundled Node runtime cannot keep a
+ *      detached child alive (e.g. Claude Desktop), the spawned server silently
+ *      never comes up, and the bridge used to give up with exit(1). Hosting
+ *      in-process is guaranteed to work because the bridge itself is already
+ *      running in a working Node runtime.
+ */
+export async function ensureServer(options: EnsureServerOptions): Promise<EnsureServerOutcome> {
+  const {
+    host,
+    port,
+    spawnDetached,
+    startInProcess,
+    probeFn = probe,
+    waitFn = waitForPort,
+    spawnWaitMs = 8000,
+    inProcessWaitMs = 8000,
+    log = () => {},
+  } = options;
+
+  if (await probeFn(host, port)) {
+    return 'already-running';
+  }
+
+  // Best-effort: a throw here (e.g. failing to open the spawn log) must not
+  // abort the in-process fallback, which is the guaranteed path.
+  try {
+    spawnDetached();
+  } catch (error) {
+    log(`detached spawn failed: ${(error as Error)?.message ?? String(error)}`);
+  }
+  if (await waitFn(host, port, { timeoutMs: spawnWaitMs })) {
+    return 'spawned';
+  }
+
+  log(
+    `detached Kapture server never bound ${host}:${port}; hosting it in-process ` +
+      `(this host's runtime cannot keep a detached child alive)`
+  );
+  try {
+    await startInProcess();
+  } catch (error) {
+    // A late-binding detached child can race the in-process listen to the port
+    // (in-process would then fail with EADDRINUSE). If something is now
+    // listening, the server is up regardless of who won, so retry succeeds.
+    if (await probeFn(host, port)) {
+      return 'already-running';
+    }
+    log(`in-process Kapture server failed to start: ${(error as Error)?.message ?? String(error)}`);
+    return 'failed';
+  }
+
+  if (await waitFn(host, port, { timeoutMs: inProcessWaitMs })) {
+    return 'in-process';
+  }
+  return 'failed';
+}

--- a/server/src/bridge.ts
+++ b/server/src/bridge.ts
@@ -6,7 +6,7 @@ import { dirname, join } from 'path';
 import { createRequire } from 'module';
 import { openSync } from 'fs';
 import { tmpdir } from 'os';
-import { probe, waitForPort } from './bridge-lib.js';
+import { ensureServer } from './bridge-lib.js';
 
 process.title = 'Kapture MCP Bridge';
 
@@ -71,29 +71,54 @@ class ReplayingMCPWebSocketBridge extends MCPWebSocketBridge {
 const serverPath = join(__dirname, 'index.js');
 const logPath = join(tmpdir(), 'kapture-server.log');
 
-async function main() {
-  // Probe before spawning: if a server (or an external supervisor) is already
-  // listening, skip the spawn entirely so the bridge is idempotent and tolerant
-  // of environments where the detached child can't take (e.g. Claude Desktop's
-  // built-in Node runtime). See issue #7.
-  if (!(await probe(HOST, PORT))) {
-    // Capture the child's stderr to a log file instead of discarding it, so a
-    // failed spawn is diagnosable rather than silent.
-    const log = openSync(logPath, 'a');
-    const serverProcess = spawn(process.execPath, [serverPath], {
-      detached: true,
-      stdio: ['ignore', log, log]
-    });
-    serverProcess.on('error', (error) => {
-      console.error('Failed to spawn Kapture server:', error);
-    });
-    serverProcess.unref();
-  }
+// Best-effort: spawn a standalone server as a detached child. Keeps the
+// shared-server model (multiple MCP clients, one server, same browser tabs)
+// when the host can keep a detached child alive. See issue #7.
+function spawnDetachedServer() {
+  // Capture the child's output to a log file, never our stdout (which is the
+  // MCP JSON-RPC channel), so a failed spawn is diagnosable rather than silent.
+  const log = openSync(logPath, 'a');
+  const serverProcess = spawn(process.execPath, [serverPath], {
+    detached: true,
+    stdio: ['ignore', log, log],
+    // If this host runs us under Electron's Node (e.g. Claude Desktop),
+    // process.execPath is the Electron binary; ELECTRON_RUN_AS_NODE makes the
+    // child run as plain Node instead of launching the desktop app. It is a
+    // no-op under a real node. Hosts that still can't keep the child alive fall
+    // through to the in-process path in ensureServer.
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  });
+  serverProcess.on('error', (error) => {
+    console.error('Failed to spawn Kapture server:', error);
+  });
+  serverProcess.unref();
+}
 
-  // Wait for the server to actually bind the port instead of a fixed delay,
-  // and fail loudly if it never comes up rather than hanging on the WebSocket
-  // connect (which surfaces to the client as a silent ~60s timeout).
-  if (!(await waitForPort(HOST, PORT))) {
+// Host the server inside this process. The module auto-starts only as the
+// process entrypoint, so importing it here does not start a second listener;
+// we call its exported startServer() explicitly.
+async function startServerInProcess() {
+  const { startServer } = await import('./index.js');
+  await startServer();
+}
+
+async function main() {
+  // Make sure a server is listening: reuse an already-running one, else spawn a
+  // detached child, else host it in-process. The in-process fallback is the fix
+  // for issue #13 ("Unable to connect to extension server"): under hosts whose
+  // bundled Node runtime cannot keep a detached child alive (e.g. Claude
+  // Desktop), the spawned server never binds the port, and the bridge used to
+  // give up with exit(1). console.error (stderr) is safe; stdout is the MCP
+  // channel.
+  const outcome = await ensureServer({
+    host: HOST,
+    port: PORT,
+    spawnDetached: spawnDetachedServer,
+    startInProcess: startServerInProcess,
+    log: (message) => console.error(message),
+  });
+
+  if (outcome === 'failed') {
     console.error(
       `Kapture server never bound ${HOST}:${PORT}. See ${logPath} for details.`
     );

--- a/server/src/browser-websocket-manager.ts
+++ b/server/src/browser-websocket-manager.ts
@@ -99,7 +99,9 @@ export class BrowserWebSocketManager {
       });
 
       ws.on('close', (e) => {
-        console.log('Connection closed', e);
+        // Must use logger (stderr), not console.log (stdout): when the bridge
+        // hosts this server in-process, stdout is the MCP JSON-RPC channel.
+        logger.log('Connection closed', e);
         clearInterval(pingInterval);
         const connection = this.tabRegistry.findByWebSocket(ws);
         if (connection) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,8 +3,9 @@
 import { WebSocketServer } from 'ws';
 import { createServer } from 'http';
 import { readFile } from 'fs/promises';
+import { realpathSync } from 'fs';
 import { join } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { dirname } from 'path';
 import { TabRegistry } from './tab-registry.js';
 import { BrowserWebSocketManager } from './browser-websocket-manager.js';
@@ -321,12 +322,6 @@ const httpServer = createServer(async (req, res) => {
   res.end(JSON.stringify({ error: 'Not found' }));
 });
 
-// HTTP server error handling
-httpServer.on('error', (error) => {
-  logger.error('HTTP server error:', error);
-  process.exit(1);
-});
-
 // ========================================================================
 // WebSocket Setup
 // ========================================================================
@@ -357,30 +352,68 @@ wss.on('connection', (ws, request) => {
 // ========================================================================
 
 /**
- * Start the HTTP server and log available endpoints
+ * Print the human-readable endpoint banner to stdout.
+ *
+ * Only safe to call from the standalone entrypoint: when the bridge hosts the
+ * server in-process, stdout is the MCP JSON-RPC channel and any stray write
+ * corrupts the protocol. The in-process path therefore never calls this.
  */
-async function startServer() {
-  await checkIfPortInUse(PORT);
+function printStartupBanner() {
+  console.log('='.repeat(70));
+  console.log('Kapture MCP Server Started');
+  console.log();
+  console.log('HTTP Endpoints:');
+  console.log(`  MCP clients: http://127.0.0.1:${PORT}/clients`);
+  console.log(`  Resources: http://127.0.0.1:${PORT}/tabs`);
+  console.log(`  Tab info: http://127.0.0.1:${PORT}/tab/{tabId}`);
+  console.log(`  Console: http://127.0.0.1:${PORT}/tab/{tabId}/console`);
+  console.log(`  Screenshot: http://127.0.0.1:${PORT}/tab/{tabId}/screenshot`);
+  console.log(`  View image: http://127.0.0.1:${PORT}/tab/{tabId}/screenshot/view`);
+  console.log(`  Elements: http://127.0.0.1:${PORT}/tab/{tabId}/elements`);
+  console.log(`  Point query: http://127.0.0.1:${PORT}/tab/{tabId}/elementsFromPoint`);
+  console.log(`  DOM: http://127.0.0.1:${PORT}/tab/{tabId}/dom`);
+  console.log(`  Commands: POST http://127.0.0.1:${PORT}/tab/{tabId}/{command}`);
+  console.log(`  New tab: POST http://127.0.0.1:${PORT}/tabs`);
+  console.log(`  Close tab: DELETE http://127.0.0.1:${PORT}/tab/{tabId}`);
+  console.log('='.repeat(70));
+}
 
-  httpServer.listen(PORT, '127.0.0.1', () => {
-    console.log('='.repeat(70));
-    console.log('Kapture MCP Server Started');
-    console.log();
-    console.log('HTTP Endpoints:');
-    console.log(`  MCP clients: http://127.0.0.1:${PORT}/clients`);
-    console.log(`  Resources: http://127.0.0.1:${PORT}/tabs`);
-    console.log(`  Tab info: http://127.0.0.1:${PORT}/tab/{tabId}`);
-    console.log(`  Console: http://127.0.0.1:${PORT}/tab/{tabId}/console`);
-    console.log(`  Screenshot: http://127.0.0.1:${PORT}/tab/{tabId}/screenshot`);
-    console.log(`  View image: http://127.0.0.1:${PORT}/tab/{tabId}/screenshot/view`);
-    console.log(`  Elements: http://127.0.0.1:${PORT}/tab/{tabId}/elements`);
-    console.log(`  Point query: http://127.0.0.1:${PORT}/tab/{tabId}/elementsFromPoint`);
-    console.log(`  DOM: http://127.0.0.1:${PORT}/tab/{tabId}/dom`);
-    console.log(`  Commands: POST http://127.0.0.1:${PORT}/tab/{tabId}/{command}`);
-    console.log(`  New tab: POST http://127.0.0.1:${PORT}/tabs`);
-    console.log(`  Close tab: DELETE http://127.0.0.1:${PORT}/tab/{tabId}`);
-    console.log('='.repeat(70));
+/**
+ * Start the HTTP/WebSocket server and resolve once it is listening on
+ * 127.0.0.1:PORT, or reject if the socket fails to bind.
+ *
+ * Unlike the standalone entrypoint below, this neither writes to stdout nor
+ * exits the process, so the bridge can host the server in-process (where
+ * stdout is the MCP stdio channel and the process must stay alive) as a
+ * fallback when it cannot keep a detached child running. See issue #13.
+ */
+export function startServer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    httpServer.once('error', onError);
+    httpServer.listen(PORT, '127.0.0.1', () => {
+      httpServer.removeListener('error', onError);
+      // Once bound, log later errors instead of crashing the (possibly shared
+      // with the bridge) process.
+      httpServer.on('error', (error) => logger.error('HTTP server error:', error));
+      resolve();
+    });
   });
+}
+
+/**
+ * True when this module is the process entrypoint (`node dist/index.js`, which
+ * is also how the bridge spawns the standalone server), as opposed to being
+ * imported by the bridge for in-process hosting.
+ */
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return import.meta.url === pathToFileURL(realpathSync(entry)).href;
+  } catch {
+    return false;
+  }
 }
 
 // ========================================================================
@@ -410,4 +443,19 @@ process.on('SIGINT', () => {
 // Start the server
 // ========================================================================
 
-startServer();
+// Only auto-start when run as the process entrypoint (standalone, or the
+// detached child the bridge spawns). When imported in-process by the bridge,
+// the bridge calls startServer() itself and handles failures, so importing
+// this module must not start listening, print to stdout, or exit.
+if (isMainModule()) {
+  (async () => {
+    await checkIfPortInUse(PORT);
+    try {
+      await startServer();
+      printStartupBanner();
+    } catch (error) {
+      logger.error('Failed to start Kapture server:', error);
+      process.exit(1);
+    }
+  })();
+}


### PR DESCRIPTION
## Problem

Fixes #13 (the most-reported connection failure; same root cause as #2).

Under **Claude Desktop**, the Kapture MCP server never comes up: Claude Desktop shows **"Could not attach to MCP server — Unable to connect to extension server. Please try disabling and re-enabling the extension."** and the Chrome extension stays on **"Searching.."**.

**Root cause.** `dist/bridge.js` (what the MCP host launches) brought the websocket server up *only* by spawning it as a detached child:

```js
spawn(process.execPath, [serverPath], { detached: true })
```

Under hosts whose bundled Node runtime can't keep a detached child alive, that child never binds port `61822`, `waitForPort` times out, and the bridge `exit(1)`s. In Claude Desktop specifically the MCP server runs under Electron's Node, where `process.execPath` is the Electron binary — so the spawned child can't become a node server at all. Commit 3c9b843 already identified this exact cause ("environments where the detached server child can't take") but only made it diagnosable.

## Fix

New `ensureServer` orchestrator (`bridge-lib.ts`):

1. **probe** — reuse an already-running server (keeps the multi-client shared-server model so all clients see the same tabs),
2. else **spawn the detached child** and wait for it to bind,
3. else **host the server in-process** inside the bridge's own process — guaranteed to work because the bridge is already a live Node runtime, and it stays alive via `stdin.resume()`.

Supporting changes:

- **`index.ts`** exports a **stdout-silent, non-exiting `startServer()`**. The standalone path (banner + port-in-use check + `exit`) now runs only when `index.js` is the process entrypoint (`isMainModule()`), so importing it in-process doesn't start a second listener, write to stdout, or exit the bridge.
- The bridge's **stdout is the MCP JSON-RPC channel** (`mcp2websocket` frames protocol via `console.log`), so a stray `console.log` on tab disconnect in `browser-websocket-manager.ts` is rerouted to `logger` (stderr). The in-process server now writes nothing to stdout.
- `ELECTRON_RUN_AS_NODE=1` is set on the detached spawn so the shared-server model still works on Electron hosts where the child *can* run (no-op on a real node).

Behavior on real-node hosts (Claude Code, terminal `npx kapture-mcp bridge`) is unchanged: the detached spawn still wins and multiple clients share one server.

## Tests / verification

- New unit tests for every `ensureServer` branch — already-running / spawned / in-process / failed / EADDRINUSE-race / throwing-spawn — including a #13 regression test. `npm test` green; `npm run build` clean.
- Verified end-to-end on Node: the in-process fallback binds `61822`, serves `/clients`, completes an MCP `initialize` handshake, and writes **zero** bytes to stdout; the real `node dist/bridge.js` happy path keeps stdout pure JSON-RPC; standalone `node dist/index.js` is unchanged (still prints the banner and listens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
