### PR TITLE
harden: pin extension origin to a known ID + gate /assistants/configure

### DIFF
--- a/server/src/index.integration.test.ts
+++ b/server/src/index.integration.test.ts
@@ -15,8 +15,9 @@ process.env.KAPTURE_PORT = String(PORT);
 
 const BASE = `http://127.0.0.1:${PORT}`;
 const WS_BASE = `ws://127.0.0.1:${PORT}`;
-const EXT = 'chrome-extension://ejfnegenodbdcodemkibocefmajjjjbn'; // the Kapture extension
-const GOOD = 'https://williamkapke.github.io';                     // allow-listed
+const EXT = 'chrome-extension://ejfnegenodbdcodemkibocefmajjjjbn';       // pinned Kapture ID
+const OTHER_EXT = 'chrome-extension://abcdefghijklmnopabcdefghijklmnop'; // some other extension
+const GOOD = 'https://williamkapke.github.io';                          // allow-listed
 const EVIL = 'https://evil.example';
 
 let startServer: () => Promise<void>;
@@ -84,14 +85,27 @@ test('HTTP preflight: hostile OPTIONS is rejected with 403', async () => {
   assert.equal(res.status, 403);
 });
 
+test('HTTP: /assistants/configure is disabled unless opted in', async () => {
+  const res = await fetch(`${BASE}/assistants/configure`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{}',
+  });
+  assert.equal(res.status, 403);
+});
+
 // ---- WebSocket upgrade -----------------------------------------------------
 
 test('WS: hostile origin upgrade is rejected (no 101)', async () => {
   assert.notEqual(await wsStatus('/', EVIL), 101);
 });
 
-test('WS: extension origin is accepted on the root path', async () => {
+test('WS: pinned extension origin is accepted on the root path', async () => {
   assert.equal(await wsStatus('/', EXT), 101);
+});
+
+test('WS: an unrelated extension origin is rejected (pinned)', async () => {
+  assert.notEqual(await wsStatus('/', OTHER_EXT), 101);
 });
 
 test('WS: extension origin is rejected on /mcp', async () => {

--- a/server/src/index.integration.test.ts
+++ b/server/src/index.integration.test.ts
@@ -1,0 +1,103 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { WebSocket } from 'ws';
+
+// Integration tests for the control-plane security wiring in index.ts: the HTTP
+// handler and the WebSocket upgrade gate, exercised over a real socket. The
+// pure allow-list logic is unit-tested in origin-policy.test.ts; these tests
+// guard the wiring (right header, right status, check in the right place) that
+// unit tests can't see.
+
+// A free, non-default port so the test never collides with a running server.
+// Must be set before importing index.ts, which reads it at module load.
+const PORT = 61999;
+process.env.KAPTURE_PORT = String(PORT);
+
+const BASE = `http://127.0.0.1:${PORT}`;
+const WS_BASE = `ws://127.0.0.1:${PORT}`;
+const EXT = 'chrome-extension://ejfnegenodbdcodemkibocefmajjjjbn'; // the Kapture extension
+const GOOD = 'https://williamkapke.github.io';                     // allow-listed
+const EVIL = 'https://evil.example';
+
+let startServer: () => Promise<void>;
+let stopServer: () => Promise<void>;
+
+before(async () => {
+  ({ startServer, stopServer } = await import('./index.js'));
+  await startServer();
+});
+
+after(async () => {
+  await stopServer();
+});
+
+// Resolve to the HTTP status of a WS upgrade attempt: 101 if accepted, or the
+// rejection code (e.g. 403). Closes the socket so no handle leaks.
+function wsStatus(path: string, origin?: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(WS_BASE + path, origin ? { origin } : undefined);
+    const done = (code: number) => { try { ws.close(); } catch { /* */ } resolve(code); };
+    ws.on('open', () => done(101));
+    ws.on('unexpected-response', (_req, res) => { ws.terminate(); resolve(res.statusCode || 0); });
+    ws.on('error', (err: any) => {
+      const m = String(err && err.message).match(/4\d\d/);
+      if (m) resolve(Number(m[0]));
+      else reject(err);
+    });
+  });
+}
+
+// ---- HTTP ------------------------------------------------------------------
+
+test('HTTP: hostile origin is rejected with 403 and no ACAO header', async () => {
+  const res = await fetch(`${BASE}/clients`, { headers: { Origin: EVIL } });
+  assert.equal(res.status, 403);
+  assert.equal(res.headers.get('access-control-allow-origin'), null);
+});
+
+test('HTTP: allow-listed origin gets its Origin reflected (never a wildcard)', async () => {
+  const res = await fetch(`${BASE}/clients`, { headers: { Origin: GOOD } });
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('access-control-allow-origin'), GOOD);
+  assert.notEqual(res.headers.get('access-control-allow-origin'), '*');
+  assert.match(res.headers.get('vary') || '', /Origin/);
+});
+
+test('HTTP: no-Origin local tooling is allowed', async () => {
+  const res = await fetch(`${BASE}/clients`);
+  assert.equal(res.status, 200);
+});
+
+test('HTTP preflight: allow-listed OPTIONS returns 204 with CORS + PNA headers', async () => {
+  const res = await fetch(`${BASE}/clients`, { method: 'OPTIONS', headers: { Origin: GOOD } });
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('access-control-allow-origin'), GOOD);
+  // Regression guard: methods/headers must survive on the preflight response,
+  // else legit dashboard preflights break.
+  assert.match(res.headers.get('access-control-allow-methods') || '', /POST/);
+  assert.ok(res.headers.get('access-control-allow-headers'));
+  assert.equal(res.headers.get('access-control-allow-private-network'), 'true');
+});
+
+test('HTTP preflight: hostile OPTIONS is rejected with 403', async () => {
+  const res = await fetch(`${BASE}/clients`, { method: 'OPTIONS', headers: { Origin: EVIL } });
+  assert.equal(res.status, 403);
+});
+
+// ---- WebSocket upgrade -----------------------------------------------------
+
+test('WS: hostile origin upgrade is rejected (no 101)', async () => {
+  assert.notEqual(await wsStatus('/', EVIL), 101);
+});
+
+test('WS: extension origin is accepted on the root path', async () => {
+  assert.equal(await wsStatus('/', EXT), 101);
+});
+
+test('WS: extension origin is rejected on /mcp', async () => {
+  assert.notEqual(await wsStatus('/mcp', EXT), 101);
+});
+
+test('WS: no-Origin client (the bridge) is accepted on /mcp', async () => {
+  assert.equal(await wsStatus('/mcp'), 101);
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -244,6 +244,13 @@ const httpServer = createServer(async (req, res) => {
 
   // Handle /assistants/configure endpoint
   if (req.url === '/assistants/configure' && req.method === 'POST') {
+    // This writes MCP-client config files on disk. Even behind the Origin gate,
+    // a no-Origin local caller can reach it, so keep it off unless opted in.
+    if (process.env.KAPTURE_ENABLE_ASSISTANT_CONFIG !== '1') {
+      res.writeHead(403, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Assistant configuration is disabled. Set KAPTURE_ENABLE_ASSISTANT_CONFIG=1 to enable.' }));
+      return;
+    }
     try {
       let body = '';
       req.on('data', chunk => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,8 +26,9 @@ import { isOriginAllowed, isWebSocketOriginAllowed } from './origin-policy.js';
 // Set process title for better identification
 process.title = 'Kapture MCP Server';
 
-// Fixed port for all connections
-const PORT = 61822;
+// Fixed port for all connections (overridable via KAPTURE_PORT for tests /
+// non-default deployments; the extension still defaults to 61822).
+const PORT = Number(process.env.KAPTURE_PORT) || 61822;
 
 // Get directory path for ES modules
 const __filename = fileURLToPath(import.meta.url);
@@ -371,8 +372,8 @@ httpServer.on('upgrade', (request, socket, head) => {
   const pathname = (request.url || '/').split('?')[0];
   if (!isWebSocketOriginAllowed(pathname, request.headers.origin)) {
     logger.warn(`Rejected WebSocket upgrade (path=${pathname}, origin=${request.headers.origin})`);
-    socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
-    socket.destroy();
+    // end() (not write()+destroy()) so the 403 bytes flush before the socket closes.
+    socket.end('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
     return;
   }
   wss.handleUpgrade(request, socket, head, (ws) => {
@@ -445,6 +446,16 @@ export function startServer(): Promise<void> {
       httpServer.on('error', (error) => logger.error('HTTP server error:', error));
       resolve();
     });
+  });
+}
+
+/**
+ * Stop the HTTP/WebSocket server. Mirrors startServer() so tests (and embedders)
+ * can shut the listener down and release the port.
+ */
+export function stopServer(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    httpServer.close((err) => (err ? reject(err) : resolve()));
   });
 }
 

--- a/server/src/origin-policy.test.ts
+++ b/server/src/origin-policy.test.ts
@@ -1,15 +1,32 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isOriginAllowed, isWebSocketOriginAllowed, parseAllowedOrigins } from './origin-policy.js';
+import { isOriginAllowed, isWebSocketOriginAllowed, parseAllowedOrigins, parseExtensionIds } from './origin-policy.js';
 
 // Tests for the control-plane Origin allow-list (origin-policy.ts).
+
+// The pinned Web Store extension ID; an unrelated extension ID must NOT pass.
+const EXT = 'chrome-extension://ejfnegenodbdcodemkibocefmajjjjbn';
+const OTHER_EXT = 'chrome-extension://abcdefghijklmnopabcdefghijklmnop';
 
 test('non-browser callers (no Origin) are allowed - scripts, bridge, curl', () => {
   assert.equal(isOriginAllowed(undefined), true);
 });
 
-test('the extension (chrome-extension://) is allowed', () => {
-  assert.equal(isOriginAllowed('chrome-extension://abcdefghijklmnopabcdefghijklmnop'), true);
+test('the pinned Kapture extension is allowed', () => {
+  assert.equal(isOriginAllowed(EXT), true);
+});
+
+test('an unrelated extension ID is rejected (extension origin is pinned)', () => {
+  assert.equal(isOriginAllowed(OTHER_EXT), false);
+  for (const path of ['/', '/mcp']) {
+    assert.equal(isWebSocketOriginAllowed(path, OTHER_EXT), false);
+  }
+});
+
+test('KAPTURE_EXTENSION_IDS adds extra extension IDs', () => {
+  const ids = parseExtensionIds('abcdefghijklmnopabcdefghijklmnop');
+  assert.ok(ids.has('ejfnegenodbdcodemkibocefmajjjjbn')); // default still present
+  assert.ok(ids.has('abcdefghijklmnopabcdefghijklmnop'));
 });
 
 test('allow-listed web origins are allowed', () => {
@@ -37,9 +54,8 @@ test('a duplicated Origin header (array) is rejected', () => {
 // extension's chrome-extension:// origin is accepted on the root path (where it
 // connects) but not on /mcp (only no-Origin MCP clients use that path).
 test('WS: extension origin is accepted on root but rejected on /mcp', () => {
-  const ext = 'chrome-extension://abcdefghijklmnopabcdefghijklmnop';
-  assert.equal(isWebSocketOriginAllowed('/', ext), true);
-  assert.equal(isWebSocketOriginAllowed('/mcp', ext), false);
+  assert.equal(isWebSocketOriginAllowed('/', EXT), true);
+  assert.equal(isWebSocketOriginAllowed('/mcp', EXT), false);
 });
 
 test('WS: no-Origin clients (the bridge / scripts) are accepted on /mcp', () => {

--- a/server/src/origin-policy.ts
+++ b/server/src/origin-policy.ts
@@ -25,8 +25,35 @@ export function parseAllowedOrigins(
 
 const ALLOWED_ORIGINS = parseAllowedOrigins();
 
-const isExtensionOrigin = (origin: string | string[] | undefined): boolean =>
-  typeof origin === 'string' && origin.startsWith('chrome-extension://');
+// The published Web Store build's extension ID. Pinning to it means a *different*
+// installed extension cannot drive Kapture just by virtue of being an extension.
+// A self-built / dev-loaded extension gets a different ID, so allow extra IDs via
+// KAPTURE_EXTENSION_IDS="aaaa...,bbbb..." for that case.
+const DEFAULT_EXTENSION_IDS = [
+  'ejfnegenodbdcodemkibocefmajjjjbn', // Kapture MCP Browser Automation (Web Store)
+];
+
+export function parseExtensionIds(
+  env: string | undefined = process.env.KAPTURE_EXTENSION_IDS,
+): Set<string> {
+  return new Set([
+    ...DEFAULT_EXTENSION_IDS,
+    ...(env || '')
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean),
+  ]);
+}
+
+const ALLOWED_EXTENSION_IDS = parseExtensionIds();
+
+const isExtensionOrigin = (
+  origin: string | string[] | undefined,
+  ids: Set<string> = ALLOWED_EXTENSION_IDS,
+): boolean =>
+  typeof origin === 'string' &&
+  origin.startsWith('chrome-extension://') &&
+  ids.has(origin.slice('chrome-extension://'.length));
 
 export function isOriginAllowed(
   origin: string | string[] | undefined,


### PR DESCRIPTION
Two hardening follow-ups on top of the Origin allow-list. **Stacked on #22** (the integration-test branch) — review/merge that first; this branch's diff against `cors-origin-handling` reduces to just the changes below once #22 lands.

### 1. Pin the extension origin
`isExtensionOrigin` currently accepts **any** `chrome-extension://` origin, so *any* extension a user has installed (or a compromised one) qualifies as "the extension" and can drive the entire control plane. A website can't forge an extension `Origin` (browsers enforce that), so the threat surface is narrow — "other extensions you installed" — but pinning closes it.

This matches only the published Web Store ID by default, with `KAPTURE_EXTENSION_IDS="aaaa...,bbbb..."` to add IDs for self-built / dev-loaded copies (which get a different ID). Easy to drop or relax the default if you'd rather keep accepting any extension.

### 2. Gate `/assistants/configure`
It writes MCP-client config files on disk. The Origin gate stops web pages, but a no-Origin local caller (e.g. `curl`) still reaches it. It now returns `403` unless `KAPTURE_ENABLE_ASSISTANT_CONFIG=1`. Open to a different default.

### Tests
Unit tests (`origin-policy.test.ts`) and the integration harness from #22 are extended to cover both: an unrelated extension ID is rejected (HTTP + WS), and the configure endpoint returns `403` by default. Full suite green (`npm test`).